### PR TITLE
check_boot_jars: add more OnePlus packages to whitelist

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -267,6 +267,11 @@ com\.nvidia\..*
 
 # OPLUS adds
 com\.oplus\..*
+net\.oneplus\..*
+oplus\..*
+vendor\.oplus\..*
+com\.oneplus\..*
+vendor\.oneplus\..*
 
 # QC adds
 com.qualcomm.qti


### PR DESCRIPTION
This will fix build error on some oneplus devices which uses oneplus camera and dolby stuff 

Thank you

Change-Id: I55ea27506f9a19e35c6c53e7bc71dd5689a21f77